### PR TITLE
Fix arm64 build issue

### DIFF
--- a/src/ggml-bitnet-lut.cpp
+++ b/src/ggml-bitnet-lut.cpp
@@ -1,6 +1,10 @@
 #include <vector>
 #include <type_traits>
 
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "ggml-bitnet.h"
 #include "ggml-quants.h"
 #include "bitnet-lut-kernels.h"


### PR DESCRIPTION
This pull request includes a small change to the `src/ggml-bitnet-lut.cpp` file. The change involves adding necessary standard library headers to the file.

* [`src/ggml-bitnet-lut.cpp`](diffhunk://#diff-46a3a4f717878400205f07b4edd5143df060889be70c29c5fb6e96d460b8f0e0R4-R7): Added `#include <string.h>`, `#include <stdio.h>`, and `#include <stdlib.h>` to ensure proper functionality and avoid potential compilation issues.